### PR TITLE
Check for an array type before wrapping in an array

### DIFF
--- a/src/BehaviorDescriptor.php
+++ b/src/BehaviorDescriptor.php
@@ -65,12 +65,18 @@ final class BehaviorDescriptor
             $params = [];
 
             if (!is_null($arranging)) {
-                $params = (array) $arranging();
+                $params = $arranging();
+                if (!is_array($params)) {
+                    $params = [$params];
+                }
             }
 
             $params = $acting(...$params);
 
-            $params = (array) $params;
+            $params = $params;
+            if (!is_array($params)) {
+                $params = [$params];
+            }
 
             $asserting(...$params);
         });

--- a/tests/Example.php
+++ b/tests/Example.php
@@ -49,3 +49,18 @@ scenario('expecting exception without message')
         throw new Exception('Woops!');
     })
     ->throws(Exception::class);
+
+scenario('not returning an array works')
+    ->given(fn () => 'this is not an array')
+    ->when(fn (string $s) => $s)
+    ->then(fn (string $s) => expect($s)->toBe('this is not an array'));
+
+
+scenario('returning an arrayable class works')
+    ->given(function () {
+        return new class {
+            public $a;
+        };
+    })
+    ->when(fn ($c) => $c)
+->then(fn ($c) => expect((array)$c)->toBe(['a' => null]));

--- a/tests/Example.php
+++ b/tests/Example.php
@@ -51,9 +51,9 @@ scenario('expecting exception without message')
     ->throws(Exception::class);
 
 scenario('not returning an array works')
-    ->given(fn ()         => 'this is not an array')
-    ->when(fn (string $s) => $s)
-    ->then(fn (string $s) => expect($s)->toBe('this is not an array'));
+    ->given(function () { return 'this is not an array'; })
+    ->when(function (string $s) { return $s; })
+    ->then(function (string $s) { expect($s)->toBe('this is not an array'); });
 
 scenario('returning an arrayable class works')
     ->given(function () {
@@ -61,5 +61,5 @@ scenario('returning an arrayable class works')
             public $a;
         };
     })
-    ->when(fn ($c) => $c)
-->then(fn ($c)     => expect((array) $c)->toBe(['a' => null]));
+    ->when(function ($c) { return $c; })
+    ->then(function ($c) { expect((array) $c)->toBe(['a' => null]); });

--- a/tests/Example.php
+++ b/tests/Example.php
@@ -51,16 +51,15 @@ scenario('expecting exception without message')
     ->throws(Exception::class);
 
 scenario('not returning an array works')
-    ->given(fn () => 'this is not an array')
+    ->given(fn ()         => 'this is not an array')
     ->when(fn (string $s) => $s)
     ->then(fn (string $s) => expect($s)->toBe('this is not an array'));
 
-
 scenario('returning an arrayable class works')
     ->given(function () {
-        return new class {
+        return new class() {
             public $a;
         };
     })
     ->when(fn ($c) => $c)
-->then(fn ($c) => expect((array)$c)->toBe(['a' => null]));
+->then(fn ($c)     => expect((array) $c)->toBe(['a' => null]));


### PR DESCRIPTION
The array casting from previous didn't work well with eloquent since it supports being casted to an array and the behaviour was unexpected  
This should fix that.

This resolves #1.
