### PR TITLE
Support pest 3

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # (macos-latest, windows-latest) 2.x-dev is under development
-        php: ['8.1', '8.2']
+        php: ['8.2', '8.3']
         dependency-version: [prefer-lowest, prefer-stable]
         parallel: ['', '--parallel']
 

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "pestphp/pest": "^2.0.0",
-        "pestphp/pest-plugin": "^2.0.0"
+        "pestphp/pest": ">=2.0",
+        "pestphp/pest-plugin": ">=2.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
         ]
     },
     "require-dev": {
-        "pestphp/pest-dev-tools": "^2.0.0"
+        "pestphp/pest-dev-tools": "^3.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.1",
-        "pestphp/pest": ">=2.0",
-        "pestphp/pest-plugin": ">=2.0"
+        "php": "^8.2",
+        "pestphp/pest": "^2.0 | ^3.0",
+        "pestphp/pest-plugin": "^2.0 | ^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION

Pest 3 is out 🪂  https://github.com/pestphp/pest/releases

> https://x.com/enunomaduro/status/1833120670194012446

I thought about using this alternative, but then I think as long as  @nunomaduro keep BC for the next releases, 
this `>= 2.0` should be fine. 
```json
        "pestphp/pest": "^2.0 | ^3.0",
        "pestphp/pest-plugin": "^2.0 | ^3.0"
```
